### PR TITLE
test: global testset for better summary table

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Chamber
 using Test
 include("matrix-a-data.jl")
 
-# @testset verbose=true "Chamber.jl tests" begin
+@testset verbose=true "Chamber.jl tests" begin
 
 @testset "GLQ_points_weights test" begin
     @test Chamber.GLQ_points_weights_hard(5) == [0 0]
@@ -35,4 +35,4 @@ include("test-matrix.jl")
 include("test-rho_rc.jl")
 include("test-exsolve.jl")
 
-# end
+end


### PR DESCRIPTION
Right now the tests summary is not very easy to read -- looks like this:
```julia
Test Summary:           | Pass  Total  Time
GLQ_points_weights test |    3      3  0.8s
Test Summary:          | Pass  Total  Time
gas_heat_capacity test |    3      3  0.0s
Test Summary: | Pass  Total  Time
initial test  |    4      4  0.2s
Test Summary:            | Pass  Total  Time
export functions Chamber |    2      2  0.0s
Test Summary:     | Pass  Total  Time
constructer of sw |    1      1  0.0s
Test Summary: | Pass  Total  Time
Matrix A      |   15     15  0.1s
Test Summary: | Pass  Total  Time
Matrix B      |    4      4  0.0s
Test Summary:        | Pass  Total  Time
Build Matrix phase=2 |    2      2  0.0s
Test Summary:        | Pass  Total  Time
Build Matrix phase=3 |   10     10  0.0s
Test Summary: | Pass  Total  Time
rho-rc        |    7      7  0.1s
Test Summary:   | Pass  Total  Time
exsolve-silicic |    2      2  0.2s
Test Summary: | Pass  Total  Time
exsolve-mafic |    2      2  0.0s
     Testing Chamber tests passed
```
To improve readability of the table, I wrapped all the testsets with a global testset. Now the table looks like this:
```julia
Test Summary:              | Pass  Total  Time
Chamber.jl tests           |   55     55  1.9s
  GLQ_points_weights test  |    3      3  0.8s
  gas_heat_capacity test   |    3      3  0.0s
  initial test             |    4      4  0.1s
  export functions Chamber |    2      2  0.0s
  constructer of sw        |    1      1  0.0s
  Matrix A                 |   15     15  0.1s
  Matrix B                 |    4      4  0.0s
  Build Matrix phase=2     |    2      2  0.0s
  Build Matrix phase=3     |   10     10  0.0s
  rho-rc                   |    7      7  0.1s
  exsolve-silicic          |    2      2  0.2s
  exsolve-mafic            |    2      2  0.0s
     Testing Chamber tests passed

#68 