### PR TITLE
Set kernel spec to simply Julia

### DIFF
--- a/notebooks/notebook_for_chamber.ipynb
+++ b/notebooks/notebook_for_chamber.ipynb
@@ -209,9 +209,9 @@
   },
   "gpuClass": "standard",
   "kernelspec": {
-   "display_name": "Julia 1.11.8",
+   "display_name": "Julia",
    "language": "julia",
-   "name": "julia-1.11"
+   "name": "julia"
   },
   "language_info": {
    "file_extension": ".jl",


### PR DESCRIPTION
This pull request makes a minor update to the notebook's kernel specification, ensuring compatibility and clarity in kernel selection.

* Updated the `kernelspec` in `notebooks/notebook_for_chamber.ipynb` to use the generic `Julia` display name and kernel name, instead of the version-specific `Julia 1.11.8` and `julia-1.11`.